### PR TITLE
Implement IronWellons32

### DIFF
--- a/source/ironWellons32.js
+++ b/source/ironWellons32.js
@@ -1,0 +1,43 @@
+// IronWellons32 is an algorithm based on the MurmurHash3 32-bit finalizer. MurmurHash3 was created by Austin Appleby
+// (aappleby), and has been released into the public domain. See https://github.com/aappleby/smhasher
+// The constants in the original algorithm (16‒0x85ebca6b‒13‒0xc2b2ae35‒16) were replaced by new constants
+// (16‒0x21f0aaad‒15‒0x735a2d97‒15) found by TheIronBorn using a tool created by Christopher Wellons (skeeto). See
+// https://github.com/skeeto/hash-prospector/issues/19
+// The JavaScript version was contributed by Pimm Hogeling.
+
+/**
+ * A `RandomGenerator` using the IronWellons32 algorithm. It's compatible with any `SeedInitializer` returning unsigned
+ * 32-bit integers, e.g. `SeedInitializer_Uint32`.
+ */
+export class RandomGenerator_IronWellons32 {
+  constructor(seed) {
+    if (typeof seed != 'number') {
+      throw new Error('IronWellons32 requires a numeric seed, instead received: ' + seed)
+    }
+    Object.assign(
+      this,
+      {
+        randomUint32() {
+          seed = Math.imul(
+            seed ^ seed >>> 16,
+            0x21f0aaad
+          )
+          seed = Math.imul(
+            seed ^ seed >>> 15,
+            0x735a2d97
+          )
+          seed =
+            (seed ^ seed >>> 15)
+              >>> 0
+          return seed
+        },
+        importState(state) {
+          seed = state >>> 0
+        },
+        exportState() {
+          return seed
+        }
+      }
+    )
+  }
+}

--- a/source/pluggablePrng.js
+++ b/source/pluggablePrng.js
@@ -8,6 +8,7 @@ export {RandomGenerator_Mulberry32} from './mulberry32.js'
 export {SeedInitializer_Uint32} from './uint32initializer.js'
 export {SeedInitializer_Uint64} from './uint64initializer.js'
 export {RandomGenerator_WebCrypto, SeedInitializer_WebCrypto} from './webCrypto.js'
+export {RandomGenerator_IronWellons32} from './ironWellons32.js';
 export {Xmur3} from './xmur3.js'
 export * as longfn from './longfn.js'
 export {Uint64} from './uint64.js'

--- a/tests/perf_all.js
+++ b/tests/perf_all.js
@@ -3,6 +3,7 @@ import {
   PluggablePRNG,
   RandomGenerator_Alea,
   SeedInitializer_Alea,
+  RandomGenerator_IronWellons32,
   RandomGenerator_Mulberry32,
   RandomGenerator_Sfc32,
   RandomGenerator_Pcg32,
@@ -35,6 +36,10 @@ const prngs = [
     'WebCrypto',
     RandomGenerator_WebCrypto,
     SeedInitializer_WebCrypto
+  ], [
+    'IronWellons32',
+    RandomGenerator_IronWellons32,
+    SeedInitializer_Uint32
   ]
 ]
 

--- a/tests/test_all.js
+++ b/tests/test_all.js
@@ -3,6 +3,7 @@ import {
   PluggablePRNG,
   RandomGenerator_Alea,
   SeedInitializer_Alea,
+  RandomGenerator_IronWellons32,
   RandomGenerator_Mulberry32,
   RandomGenerator_Sfc32,
   RandomGenerator_Pcg32,
@@ -35,6 +36,10 @@ const prngs = [
     'WebCrypto',
     RandomGenerator_WebCrypto,
     SeedInitializer_WebCrypto
+  ], [
+    'IronWellons32',
+    RandomGenerator_IronWellons32,
+    SeedInitializer_Uint32
   ]
 ]
 

--- a/tests/test_state_changes.js
+++ b/tests/test_state_changes.js
@@ -3,6 +3,7 @@ import {
   PluggablePRNG,
   RandomGenerator_Alea,
   SeedInitializer_Alea,
+  RandomGenerator_IronWellons32,
   RandomGenerator_Mulberry32,
   RandomGenerator_Sfc32,
   RandomGenerator_Pcg32,
@@ -38,6 +39,9 @@ const prngs = [
   ], [
     RandomGenerator_WebCrypto,
     SeedInitializer_WebCrypto
+  ], [
+    RandomGenerator_IronWellons32,
+    SeedInitializer_Uint32
   ]
 ]
 


### PR DESCRIPTION
This PR implements IronWellons32.

IronWellons32 is based on [the MurmurHash3 32-bit finalizer](//github.com/aappleby/smhasher/blob/92cf3702fcfaadc84eb7bef59825a23e0cd84f56/src/MurmurHash3.cpp#L68) (just like Xmur3 is). The constants in the original algorithm (`16‒0x85ebca6b‒13‒0xc2b2ae35‒16`) were [replaced by new constants](//github.com/skeeto/hash-prospector/issues/19) (`16‒0x21f0aaad‒15‒0x735a2d97‒15`).

The algorithm matches the speed of Alea & Mash and Mulberry32, and has a very low (=good) [avalanche score](//nullprogram.com/blog/2018/07/31/).

The essence of the algorithm is as follows:
```typescript
function* ironWellons32(seed) {
	do {
		seed = Math.imul(
			seed ^ seed >>> 16,
			0x21f0aaad
		);
		seed = Math.imul(
			seed ^ seed >>> 15,
			0x735a2d97
		);
		seed = (
			seed ^ seed >>> 15
		) >>> 0;
		yield seed;
	} while(true);
}
```

Credits: [Austin Appleby](//github.com/aappleby) created MurmurHash3; [TheIronBorn](//github.com/TheIronBorn) found the new constants, using a tool created by [Christopher Wellons](//github.com/skeeto).